### PR TITLE
Various small improvements

### DIFF
--- a/module-setup.sh
+++ b/module-setup.sh
@@ -11,7 +11,7 @@ depends() {
 }
 
 installkernel() {
-    inst_multiple grep rmdir
+    inst_multiple mountpoint rmdir dd tr
     # Filesystem (vfat) and codepages required to mount the ESP
     hostonly="" instmods vfat nls_cp437 nls_iso8859-1
 }
@@ -22,8 +22,8 @@ install() {
     # easy execute the service when the ESP device is ready and the
     # systemd-cryptsetup service was still not executed
     # (cryptsetup.target).  One solution is to use a generator, that
-    # will after/requires from dev-disk-bytpartuuid-XXX, where XXX
+    # will after/requires from dev-disk-by-partuuid-XXX, where XXX
     # comes from LoaderDevicePartUUID efivar.  The other option is an
-    # override (this one)
+    # override (this one).
     inst_simple "${moddir}/pcr-signature.conf" "/etc/systemd/system/systemd-cryptsetup@.service.d/pcr-signature.conf"
 }

--- a/pcr-signature.sh
+++ b/pcr-signature.sh
@@ -1,64 +1,42 @@
 #!/bin/bash
+set -euo pipefail
 
-MNT="/tmp/pcr-signature"
-# Maybe a better place is loader/credentials
-SYSTEMD="EFI/systemd"
-OPENSUSE="EFI/opensuse"
-SIGNATURES=""
-VENDOR="4a67b082-0a4c-41cf-b6c7-440b29bb8c4f"
 # If GRUB2 is used, bli.mod needs to be loaded
-EFIVAR="/sys/firmware/efi/efivars/LoaderDevicePartUUID-$VENDOR"
+EFIVAR="/sys/firmware/efi/efivars/LoaderDevicePartUUID-4a67b082-0a4c-41cf-b6c7-440b29bb8c4f"
+
+[ -e "$EFIVAR" ] || exit 0
+
+if [ -e "/var/lib/systemd/pcrlock.json" ] || [ -e "/etc/systemd/tpm2-pcr-signature.json" ]; then
+	# Already ran?
+	exit 0
+fi
+
+# Read the value of the EFI variable, that contains a header and
+# ends with '\0' and make it lowercase
+ESP_UUID="$(dd "if=$EFIVAR" bs=2 skip=2 conv=lcase status=none | tr -d '\0')"
+DEV="/dev/disk/by-partuuid/${ESP_UUID}"
+MNT="$(mktemp -d)"
 
 cleanup()
 {
-    is_mount "$MNT" && umount "$MNT"
-    rmdir "$MNT"
+	if mountpoint -q "$MNT"; then
+		umount "$MNT"
+	fi
+	rmdir "$MNT"
 }
 trap cleanup EXIT
 
-is_mount() {
-    grep -q "$1" /proc/mounts
-}
+mount -o ro "$DEV" "$MNT"
 
-mount_esp() {
-    [ -e "$EFIVAR" ] || return 0
-    mount "$DEV" "$MNT"
-    if [ -e "${MNT}/${SYSTEMD}" ]; then
-	SIGNATURES="$SYSTEMD"
-	return 0
-    elif [ -e "${MNT}/${OPENSUSE}" ]; then
-	SIGNATURES="$OPENSUSE"
-	return 0
-    fi
-    umount "$MNT"
-}
-
-read_efivar() {
-    local var="$1"
-    local val
-
-    # Read the value of the EFI variable, that contains a header and
-    # ends with '\0' and make it lowercase
-    read -r val < "$var"
-    val="${val:1}"
-    echo "${val,,}"
-}
-
-DEV="/dev/disk/by-partuuid/$(read_efivar "$EFIVAR")"
-
-mkdir -p "$MNT"
-
-mount_esp
-
-if is_mount "$MNT"; then
-    if [ -e "${MNT}/${SIGNATURES}/pcrlock.json" ]; then
-	mkdir -p /var/lib/systemd
-	cp "${MNT}/${SIGNATURES}/pcrlock.json" /var/lib/systemd
-    elif [ -e "${MNT}/${SIGNATURES}/tpm2-pcr-signature.json" ] && [ -e "${MNT}/${SIGNATURES}/tpm2-pcr-public-key.pem" ]; then
-	mkdir -p /etc/systemd
-	cp "${MNT}/${SIGNATURES}/tpm2-pcr-signature.json" /etc/systemd
-	cp "${MNT}/${SIGNATURES}/tpm2-pcr-public-key.pem" /etc/systemd
-    fi
-fi
-
-is_mount "$MNT" && umount "$MNT"
+for location in "${MNT}/EFI/systemd" "${MNT}/EFI/opensuse"; do
+	if [ -e "${location}/pcrlock.json" ]; then
+		mkdir -p /var/lib/systemd
+		cp "${location}/pcrlock.json" /var/lib/systemd
+		break
+	elif [ -e "${location}/tpm2-pcr-signature.json" ] && [ -e "${location}/tpm2-pcr-public-key.pem" ]; then
+		mkdir -p /etc/systemd
+		cp "${location}/tpm2-pcr-signature.json" /etc/systemd
+		cp "${location}/tpm2-pcr-public-key.pem" /etc/systemd
+		break
+	fi
+done


### PR DESCRIPTION
- Avoid using bash for working with binary data, use dd + tr instead
- Mount the ESP read-only
- Detect if policy files already exist in the destination
- Use mktemp -d instead of hardcoding a location

Draft because not tested in production yet.