### PR TITLE
Use installkernel() only to install kernel modules

### DIFF
--- a/module-setup.sh
+++ b/module-setup.sh
@@ -6,17 +6,13 @@ check() {
     return 0
 }
 
-depends() {
-    return 0
-}
-
 installkernel() {
-    inst_multiple mountpoint rmdir dd tr mktemp
     # Filesystem (vfat) and codepages required to mount the ESP
     hostonly="" instmods vfat nls_cp437 nls_iso8859-1 nls_utf8
 }
 
 install() {
+    inst_multiple mountpoint rmdir dd tr mktemp
     inst_script "$moddir/pcr-signature.sh" /usr/bin/pcr-signature.sh
     # There is a cryptsetup-pre.target that can be used, but is not
     # easy execute the service when the ESP device is ready and the


### PR DESCRIPTION
Otherwise, `--kernel-only` and `--no-kernel` produce unexpected results.

```
$ dracut -f --kernel-only test.img
$ lsinitrd test.img | grep usr/bin
drwxr-xr-x   1 root     root            0 Aug  1 09:10 usr/bin
-rwxr-xr-x   1 root     root        63840 Apr 13 20:32 usr/bin/dd
-rwxr-xr-x   1 root     root        39232 Apr 13 20:32 usr/bin/mktemp
-rwxr-xr-x   1 root     root        18624 Jun 25 00:41 usr/bin/mountpoint
-rwxr-xr-x   1 root     root        35040 Apr 13 20:32 usr/bin/rmdir
-rwxr-xr-x   1 root     root        47424 Apr 13 20:32 usr/bin/tr
$ dracut -f --no-kernel test.img
$ lsinitrd test.img | grep -w -e usr/bin/dd -e usr/bin/mktemp -e usr/bin/mountpoint -e usr/bin/rmdir -e usr/bin/tr
-rwxr-xr-x   1 root     root        47424 Apr 13 20:32 usr/bin/tr
```